### PR TITLE
Add ::SubstituteAndReturn support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist-Zilla-Plugin-Babble
 
 {{$NEXT}}
+	  Add ::SubstituteAndReturn support.
 
 0.001     2018-08-19 19:51:03+02:00 Europe/Amsterdam
           Initial release to an unsuspecting world

--- a/lib/Dist/Zilla/Plugin/Babble.pm
+++ b/lib/Dist/Zilla/Plugin/Babble.pm
@@ -42,11 +42,11 @@ has plugins => (
 );
 
 my %supported_since = (
-	'::CoreSignatures' => '5.028',
-	'::State'          => '5.010',
-	'::DefinedOr'      => '5.010',
-	'::PostfixDeref'   => '5.020',
-	'::PostfixDeref'   => '5.014',
+	'::CoreSignatures'        => '5.028',
+	'::State'                 => '5.010',
+	'::DefinedOr'             => '5.010',
+	'::PostfixDeref'          => '5.020',
+	'::SubstituteAndReturn'   => '5.014',
 );
 
 sub _build_plugins {


### PR DESCRIPTION
`::SubstituteAndReturn` was added in 5.014
<https://metacpan.org/pod/Syntax::Construct#/r>.
